### PR TITLE
Move @SharedLoader to common super class

### DIFF
--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/AbstractObjectStorageOperator.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/AbstractObjectStorageOperator.java
@@ -20,6 +20,7 @@ import com.ibm.streams.operator.OperatorContext.ContextCheck;
 import com.ibm.streams.operator.compile.OperatorContextChecker;
 import com.ibm.streams.operator.logging.LoggerNames;
 import com.ibm.streams.operator.logging.TraceLevel;
+import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streamsx.objectstorage.client.Constants;
 import com.ibm.streamsx.objectstorage.client.IObjectStorageClient;
 import com.ibm.streamsx.objectstorage.client.ObjectStorageClientFactory;
@@ -31,6 +32,7 @@ import com.ibm.streamsx.objectstorage.client.ObjectStorageClientFactory;
  * @author streamsadmin
  *
  */
+@SharedLoader
 public abstract class AbstractObjectStorageOperator extends AbstractOperator  {
 
 	private static final String CLASS_NAME = "com.ibm.streamsx.objectstorage.AbstractObjectStorageOperator";

--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/ObjectStorageScan.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/ObjectStorageScan.java
@@ -7,7 +7,6 @@ import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streams.operator.model.InputPortSet.WindowMode;
 import com.ibm.streams.operator.model.InputPortSet.WindowPunctuationInputMode;
 import com.ibm.streams.operator.model.OutputPortSet.WindowPunctuationOutputMode;
@@ -18,7 +17,6 @@ description=ObjectStorageScan.DESC+ObjectStorageScan.BASIC_DESC+AbstractObjectSt
 @OutputPorts({
 		@OutputPortSet(description = "The `ObjectStorageScan` operator has one output port. This port provides tuples of type rstring that are encoded in UTF-8 and represent the object names that are found in the directory, one object name per tuple. The object names do not occur in any particular order.", cardinality = 1, optional = false, windowPunctuationOutputMode = WindowPunctuationOutputMode.Free)})
 @Libraries({"opt/*","opt/downloaded/*" })
-@SharedLoader
 public class ObjectStorageScan extends BaseObjectStorageScan implements IObjectStorageAuth {
 
 	public static final String DESC = 

--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/ObjectStorageSource.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/ObjectStorageSource.java
@@ -7,7 +7,6 @@ import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streams.operator.model.InputPortSet.WindowMode;
 import com.ibm.streams.operator.model.InputPortSet.WindowPunctuationInputMode;
 import com.ibm.streams.operator.model.OutputPortSet.WindowPunctuationOutputMode;
@@ -18,7 +17,6 @@ description=ObjectStorageSource.DESC+ObjectStorageSource.BASIC_DESC+AbstractObje
 @InputPorts({@InputPortSet(description="The `ObjectStorageSource` operator has one optional input port. If an input port is specified, the operator expects an input tuple with a single attribute of type rstring. The input tuples contain the object names that the operator opens for reading. The input port is non-mutating.", cardinality=1, optional=true, windowingMode=WindowMode.NonWindowed, windowPunctuationInputMode=WindowPunctuationInputMode.Oblivious)})
 @OutputPorts({@OutputPortSet(description="The `ObjectStorageSource` operator has one output port. The tuples on the output port contain the data that is read from the objects. The operator supports two modes of reading.  To read an object line-by-line, the expected output schema of the output port is tuple<rstring line>. To read an object as binary, the expected output schema of the output port is tuple<blob data>. Use the blockSize parameter to control how much data to retrieve on each read. The operator includes a punctuation marker at the conclusion of each object.", cardinality=1, optional=false, windowPunctuationOutputMode=WindowPunctuationOutputMode.Generating)})
 @Libraries({"opt/*","opt/downloaded/*" })
-@SharedLoader
 public class ObjectStorageSource extends BaseObjectStorageSource implements IObjectStorageAuth {
 	
 	public static final String DESC = 

--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageScan.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageScan.java
@@ -8,7 +8,6 @@ import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streams.operator.model.InputPortSet.WindowMode;
 import com.ibm.streams.operator.model.InputPortSet.WindowPunctuationInputMode;
 import com.ibm.streamsx.objectstorage.BaseObjectStorageScan;
@@ -24,7 +23,6 @@ description=S3ObjectStorageScan.DESC+ObjectStorageScan.BASIC_DESC)
 @OutputPorts({
 		@OutputPortSet(description = "The `S3ObjectStorageScan` operator has one output port. This port provides tuples of type rstring that are encoded in UTF-8 and represent the object names that are found in the directory, one object name per tuple. The object names do not occur in any particular order.", cardinality = 1, optional = false, windowPunctuationOutputMode = WindowPunctuationOutputMode.Free)})
 @Libraries({"opt/*","opt/downloaded/*" })
-@SharedLoader
 public class S3ObjectStorageScan extends BaseObjectStorageScan implements IS3ObjectStorageAuth {
 
 	public static final String DESC = 

--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageSink.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageSink.java
@@ -11,7 +11,6 @@ import com.ibm.streams.operator.model.OutputPortSet.WindowPunctuationOutputMode;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streamsx.objectstorage.BaseObjectStorageSink;
 import com.ibm.streamsx.objectstorage.Utils;
 import com.ibm.streamsx.objectstorage.client.Constants;
@@ -22,7 +21,6 @@ description=S3ObjectStorageSink.DESC+ObjectStorageSink.BASIC_DESC+ObjectStorageS
 @InputPorts({@InputPortSet(description="The `S3ObjectStorageSink` operator has one input port, which writes the contents of the input stream to the object that you specified. The `S3ObjectStorageSink` supports writing data into object storage in two formats. For line format, the schema of the input port is tuple<rstring line>, which specifies a single rstring attribute that represents a line to be written to the object. For binary format, the schema of the input port is tuple<blob data>, which specifies a block of data to be written to the object.", cardinality=1, optional=false, windowingMode=WindowMode.NonWindowed, windowPunctuationInputMode=WindowPunctuationInputMode.Oblivious)})
 @OutputPorts({@OutputPortSet(description="The `S3ObjectStorageSink` operator is configurable with an optional output port. The schema of the output port is <rstring objectName, uint64 objectSize>, which specifies the name and size of objects that are written to object storage. Note, that the tuple is generated on the object upload completion.", cardinality=1, optional=true, windowPunctuationOutputMode=WindowPunctuationOutputMode.Generating)})
 @Libraries({"opt/*","opt/downloaded/*" })
-@SharedLoader
 public class S3ObjectStorageSink extends BaseObjectStorageSink implements IS3ObjectStorageAuth {
 	
 	public static final String DESC = 

--- a/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageSource.java
+++ b/com.ibm.streamsx.objectstorage/impl/java/src/com/ibm/streamsx/objectstorage/s3/S3ObjectStorageSource.java
@@ -8,7 +8,6 @@ import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.SharedLoader;
 import com.ibm.streamsx.objectstorage.BaseObjectStorageSource;
 import com.ibm.streamsx.objectstorage.ObjectStorageSource;
 import com.ibm.streamsx.objectstorage.Utils;
@@ -23,7 +22,6 @@ description=S3ObjectStorageSource.DESC+ObjectStorageSource.BASIC_DESC)
 @InputPorts({@InputPortSet(description="The `S3ObjectStorageSource` operator has one optional input port. If an input port is specified, the operator expects an input tuple with a single attribute of type rstring. The input tuples contain the object names that the operator opens for reading. The input port is non-mutating.", cardinality=1, optional=true, windowingMode=WindowMode.NonWindowed, windowPunctuationInputMode=WindowPunctuationInputMode.Oblivious)})
 @OutputPorts({@OutputPortSet(description="The `S3ObjectStorageSource` operator has one output port. The tuples on the output port contain the data that is read from the objects. The operator supports two modes of reading.  To read an object line-by-line, the expected output schema of the output port is tuple<rstring line>. To read an object as binary, the expected output schema of the output port is tuple<blob data>. Use the blockSize parameter to control how much data to retrieve on each read. The operator includes a punctuation marker at the conclusion of each object.", cardinality=1, optional=false, windowPunctuationOutputMode=WindowPunctuationOutputMode.Generating)})
 @Libraries({"opt/*","opt/downloaded/*" })
-@SharedLoader
 public class S3ObjectStorageSource extends BaseObjectStorageSource  implements IS3ObjectStorageAuth {
 
 	public static final String DESC = 


### PR DESCRIPTION
`@SharedLoader` inherits and by setting it at the super class level it ensures that any new operator automatically picks it up.